### PR TITLE
disable 'renovate' for now

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "enabled": false
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#enabled

updating the packages is not trivial, because:

- no integration tests available
- no UI-interaction-tests available
- used versions are very old

'renovate' cannot detect different problems, so, for now (until the packages are updated enough by manual engineering/testing), this tools should be disabled.

(note that even if the build passes, this does not mean that the resulting software has no problems. e.g. here: https://github.com/deepnest-io/Deepnest/pull/13/checks)