### PR TITLE
rename `npm run` scripts:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Deepnest Changelong
-(newest on top)
+(newest on top, breaking changes)
 
 
+2023-05-15 rename `npm run` scripts: fullbuild->build-all, fullclean->clean-all
+           introduced dist-all that includes a full clean rebuild with dist
 2023-05-14 removed all `npm run` hardcoded filesystem references to `Dogthemachine`
            aliased the w:* commands to *
 2023-05-13  `npm run w:dist` now overwrites an existent dist directory of the same name

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm run start
 npm run build
 
 # If you change the the Minkowski files (the `.cc` or `.h` files):
-npm run fullbuild
+npm run build-all
 ```
 
 ## Running
@@ -76,13 +76,17 @@ executable files that can be run without dependency on the build environment), y
 
 Two clean options:
 - For regular clean of build artifacts, use `npm run clean` and then `npm run build`.
-- To remove everything, including `node_modules` use `npm run fullclean`, then [build](#building) again.
+- To remove everything, including `node_modules` use `npm run clean-all`, then [build](#building) again.
 
 ## Create a distribution build
 
 To build a distribution set of files, run:
 
 - `npm run dist`
+
+For your convenience especially during development combine `clean-all, build-all and dist` via:
+
+- `npm run dist-all`
 
 The resulting files will be located in `.\deepnest-win32-x64`.  All files need to be distributed,
 meaning a ZIP file or writing a simple installer would be needed to avoid handling a larger number

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   "scripts": {
     "start": "electron .",
     "configure": "node-gyp configure --release",
-    "fullbuild": "node-gyp rebuild && mkdir minkowski >nul 2>&1|echo.>nul && npm run build",
+    "build-all": "node-gyp rebuild && mkdir minkowski >nul 2>&1|echo.>nul && npm run build",
     "build": "mkdir minkowski >nul 2>&1|echo.>nul && mkdir minkowski\\Release >nul 2>&1|echo.>nul && .\\node_modules\\.bin\\electron-rebuild.cmd && npm run copy",
     "clean": "rmdir /s /q build dist >nul 2>&1|echo.>nul",
-    "fullclean": "rmdir /s /q build dist node_modules minkowski bin >nul 2>&1|echo.>nul",
+    "clean-all": "rmdir /s /q build dist node_modules minkowski bin >nul 2>&1|echo.>nul",
     "dist": ".\\node_modules\\.bin\\electron-packager . deepnest --platform=win32 --arch=x64 --overwrite",
+    "dist-all": "npm run clean-all && npm install && npm run build-all && npm run dist",
     "copy": "xcopy /s /y .\\build\\Release .\\minkowski\\Release"
   },
   "repository": "https://github.com/deepnest-io/Deepnest",


### PR DESCRIPTION
fullbuild -> build-all,
fullclean -> clean-all
introduced dist-all that includes a full clean rebuild with dist